### PR TITLE
Jenkins/Docker config fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
     agent { 
         docker { 
             image 'vc'
+            args '-u root'
         } 
     }
     stages {
@@ -9,6 +10,11 @@ pipeline {
             steps {
                 sh './build.sh'
             }
+        }
+    }
+    post { 
+        always { 
+            cleanWs()
         }
     }
 }


### PR DESCRIPTION
Edited Jenkins/Docker configuration to allow for correct permissions checking out and cleaning up workspace on Jenkins server. Was getting permissions errors when checking out/cleaning workspace without this.

