### PR TITLE
Improve windows build experience

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "libs/ecu-sim"]
 	path = libs/ecu-sim
-	url = git@github.com:RITRacingSoftware/ecu-sim.git
+	url = https://github.com/RITRacingSoftware/ecu-sim.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ USER root
 
 WORKDIR /vc
 
-# Move everything in the vc folder to the docker container file system
-COPY . /vc/
-
 # disable prompts during apt-get
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -25,6 +22,9 @@ cmake \
 doxygen \
 gdb-multiarch \
 graphviz
+
+# Move everything in the vc folder to the docker container file system
+COPY . /vc/
 
 RUN cd libs/ecu-sim/libs/vector_blf && touch LICENSE.GPL-3.0 && mkdir -p build && cd build && cmake .. && make && make install DESTDIR=.. && make install && /usr/sbin/ldconfig
 

--- a/enter-docker.cmd
+++ b/enter-docker.cmd
@@ -1,0 +1,3 @@
+docker run -it ^
+	--mount type=bind,source=%cd%,destination=/ssdb ^
+	vc

--- a/enter-docker.cmd
+++ b/enter-docker.cmd
@@ -1,3 +1,3 @@
 docker run -it ^
-	--mount type=bind,source=%cd%,destination=/ssdb ^
+	--mount type=bind,source=%cd%,destination=/vc ^
 	vc

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,0 +1,2 @@
+git submodule update --init --recursive
+docker build . -t vc


### PR DESCRIPTION
This PR:

- Adds `setup.cmd` and `enter-docker.cmd` for windows building
- Reorders `Dockerfile` for reduced rebuild times
- Changes ecu-sim submodule to an http url to fix unauthenticated clones